### PR TITLE
fix issue with params.pp with strict_variables enabled

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,17 +10,25 @@ class erlang::params {
     'Debian' : {
       $key_signature            = 'D208507CA14F4FCA'
       $package_name             = 'erlang-nox'
+      $local_repo_location      = undef
       $remote_repo_key_location = 'http://packages.erlang-solutions.com/debian/erlang_solutions.asc'
       $remote_repo_location     = 'http://packages.erlang-solutions.com/debian'
       $repos                    = 'contrib'
     }
     'RedHat', 'SUSE', 'Archlinux' : {
-      $package_name = 'erlang'
+      $key_signature  = undef
+      $package_name   = 'erlang'
 
       if $::operatingsystemrelease =~ /^5/ {
         $local_repo_location  = '/etc/yum.repos.d/epel-erlang.repo'
         $remote_repo_location = 'https://repos.fedorapeople.org/repos/peter/erlang/epel-erlang.repo'
+      } else {
+        $local_repo_location  = undef
+        $remote_repo_location = undef
       }
+
+      $remote_repo_key_location = undef
+      $repos                    = undef
     }
     default : {
       fail("The ${module_name} module is not supported on an ${::osfamily} based system.")


### PR DESCRIPTION
With strict_variables enabled Puppet runs will fail if a variable is referenced but is not defined. The error you receive is Evaluation Error: Unknown variable:.

https://docs.puppetlabs.com/references/latest/configuration.html#strictvariables

There are several chances for this to happen because of the conditional variable definitions in params.pp. This pull request ensures all referenced variables are defined in params.pp.