### PR TITLE
Specify full key fingerprint, instead of partial

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,7 +8,7 @@ class erlang::params {
 
   case $::osfamily {
     'Debian' : {
-      $key_signature            = 'D208507CA14F4FCA'
+      $key_signature            = '434975BD900CCBE4F7EE1B1ED208507CA14F4FCA'
       $package_name             = 'erlang-nox'
       $remote_repo_key_location = 'http://packages.erlang-solutions.com/debian/erlang_solutions.asc'
       $remote_repo_location     = 'http://packages.erlang-solutions.com/debian'


### PR DESCRIPTION
Newer editions of the puppetlabs/apt module warn if the fingerprint is
partial, this corrects this.

Eliminates this warning:
Warning: /Apt_key[Add key: D208507CA14F4FCA from Apt::Source erlang]: The id should be a full fingerprint (40 characters), see README.