### PR TITLE
Removing requirement for EPEL on RedHat/Centos and Erlang-solutions repository

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,6 @@
 #   Defaults to present.
 #
 class erlang (
-  $epel_enable              = $erlang::params::epel_enable,
   $key_signature            = $erlang::params::key_signature,
   $local_repo_location      = $erlang::params::local_repo_location,
   $package_name             = $erlang::params::package_name,
@@ -26,16 +25,7 @@ class erlang (
       include '::erlang::repo::apt'
     }
     'RedHat' : {
-      if $epel_enable {
-        # Include epel as this is a requirement for erlang in RHEL6.
-        include '::epel'
-        Class['epel'] -> Package[$package_name]
-      }
-
-      # This is only needed on RHEL5, RHEL6 has erlang in EPEL.
-      if $::operatingsystemrelease =~ /^5/ {
         include '::erlang::repo::yum'
-      }
     }
     default : {
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,6 @@
 # operating systems
 #
 class erlang::params {
-  $epel_enable = false
 
   case $::osfamily {
     'Debian' : {
@@ -23,8 +22,8 @@ class erlang::params {
         $local_repo_location  = '/etc/yum.repos.d/epel-erlang.repo'
         $remote_repo_location = 'https://repos.fedorapeople.org/repos/peter/erlang/epel-erlang.repo'
       } else {
-        $local_repo_location  = undef
-        $remote_repo_location = undef
+        $local_repo_location  = '/etc/yum.repos.d/erlang-solutions.repo'
+        $remote_repo_location = 'http://packages.erlang-solutions.com/rpm/centos/erlang_solutions.repo'
       }
 
       $remote_repo_key_location = undef

--- a/metadata.json
+++ b/metadata.json
@@ -44,12 +44,14 @@
     },
     {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": [ 
+        "3.x", 
+        "4.x" 
+      ]
     }
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=2.0.0 <5.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">=2.1.0" },
-    { "name": "stahnma/epel", "version_requirement": ">=1.0.0 <2.0.0" }
+    { "name": "puppetlabs/apt", "version_requirement": ">=2.1.0" }
   ]
 }

--- a/spec/classes/erlang_spec.rb
+++ b/spec/classes/erlang_spec.rb
@@ -49,16 +49,6 @@ describe 'erlang', :type => :class do
   context 'on RedHat 5' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystemrelease => '5.9' } }
 
-    context "epel enabled" do
-      let(:params) {{ :epel_enable => true }}
-      it { should contain_class('epel') }
-    end
-
-    context "epel disabled" do
-      let(:params) {{ :epel_enable => false }}
-      it { should_not contain_class('epel') }
-    end
-
     context 'with no parameters' do
       it { should contain_package('erlang').with_ensure('present') }
       it { should contain_exec('erlang-repo-download').with(
@@ -89,25 +79,32 @@ describe 'erlang', :type => :class do
   context 'on RedHat 6' do
     let(:facts) { {:osfamily => 'RedHat', :operatingsystemrelease => '6.4' } }
 
-    context "epel enabled" do
-      let(:params) {{ :epel_enable => true }}
-      it { should contain_class('epel') }
-    end
-
-    context "epel disabled" do
-      let(:params) {{ :epel_enable => false }}
-      it { should_not contain_class('epel') }
-    end
-
-    context 'with no parameters' do
+  context 'with no parameters' do
       it { should contain_package('erlang').with_ensure('present') }
+      it { should contain_exec('erlang-repo-download').with(
+        'command' => 'curl -o /etc/yum.repos.d/erlang-solutions.repo http://packages.erlang-solutions.com/rpm/centos/erlang_solutions.repo',
+        'path'    => '/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin'
+        )
+      }
+    end
+
+    context 'with a custom repository' do
+      let(:params) { {
+          'local_repo_location'  => '/tmp/yum.repos.d/tmp.repo',
+          'remote_repo_location' => 'http://example.com/fake.repo',
+        } }
+
+      it { should contain_exec('erlang-repo-download').with(
+        'command' => 'curl -o /tmp/yum.repos.d/tmp.repo http://example.com/fake.repo'
+        )
+      }
     end
 
     context 'with a custom version' do
       let(:params) { {'version' => 'absent' } }
       it { should contain_package('erlang').with_ensure('absent') }
     end
-  end
+  end 
 
   context 'on SUSE' do
     let(:facts) {{ :osfamily => 'SUSE', }}

--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -12,6 +12,5 @@ RSpec.configure do |c|
     puppet_install
     puppet_module_install(:source => proj_root, :module_name => 'erlang')
     shell('puppet module install puppetlabs-apt')
-    shell('puppet module install stahnma-epel')
   end
 end

--- a/spec/system/erlang_spec.rb
+++ b/spec/system/erlang_spec.rb
@@ -3,9 +3,7 @@ require 'spec_helper_system'
 describe 'The erlang puppet module' do
   it 'should run without errors' do
     pp = <<-EOS
-      class { 'erlang':
-        epel_enable => true
-      }
+      class { 'erlang': }
     EOS
 
     puppet_apply(pp) do |r|


### PR DESCRIPTION
Create and use the erlang-solutions repository for RedHat/Centos. Also remove the requirement to use EPEL so that you can get a more modern version of erlang installed.

This is similar to the setup for APT in the module currently

Moved to new branch... replaces PR #21
